### PR TITLE
Adding link of remote-china

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@
 - [Nomad List](http://nomadlist.io/) - 最适宜生活和远程工作的城市排名，对比了生活成本，气候，网速等因素。
 - [Amazing Home Offices](https://www.pinterest.com/workshifting/amazing-home-preoffices/) - 如果布置自己家里的办公环境，这里有很多参考
 - [Smart Remote Work](http://www.smartremotework.com/) - 一个远程工作相关的博客，并且也有 Weekly Newsletter 可以订阅。
-
+- [remote-china](https://remote-china.tech) - 寻找中国最酷的远程工作
 [⬆︎返回目录](#toc)
 
 ## 其它列表

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 - [Amazing Home Offices](https://www.pinterest.com/workshifting/amazing-home-preoffices/) - 如果布置自己家里的办公环境，这里有很多参考
 - [Smart Remote Work](http://www.smartremotework.com/) - 一个远程工作相关的博客，并且也有 Weekly Newsletter 可以订阅。
 - [remote-china](https://remote-china.tech) - 寻找中国最酷的远程工作
+
 [⬆︎返回目录](#toc)
 
 ## 其它列表


### PR DESCRIPTION
添加 [remote-china](https://remote-china.tech/) 在其他资源列表里。

remote-china旨在寻找中国最酷的远程工作以及具有远程工作文化的公司，目前网站还在建设中，目前主要集中精力在收集优秀公司的信息以及采访有远程工作经历的工程师。