### PR TITLE
删除角马原力社区

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,6 @@
 
 - [一早一晚](http://yizaoyiwan.com/)
 - [~~V2MM~~](https://v2mm.tech/)
-- [角马原力社区](http://www.gnuforce.com/community)
 - [豆瓣小组 - 远程工作者](https://www.douban.com/group/remoteworking)
 - [豆瓣小组 - 远程工作党](https://www.douban.com/group/freejobs/)
 - [豆瓣小组 - 兼职文案](https://www.douban.com/group/292715/)


### PR DESCRIPTION
原因：已经无法打开该网站